### PR TITLE
Payment gateway can disable invoice generation

### DIFF
--- a/src/migrations/20210324121807_payment_gateways_add_invoice_config.php
+++ b/src/migrations/20210324121807_payment_gateways_add_invoice_config.php
@@ -1,0 +1,13 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class PaymentGatewaysAddInvoiceConfig extends AbstractMigration
+{
+    public function change()
+    {
+        $this->table('payment_gateways')
+            ->addColumn('invoice', 'boolean', ['default' => true])
+            ->update();
+    }
+}

--- a/src/model/Generator/InvoiceGenerator.php
+++ b/src/model/Generator/InvoiceGenerator.php
@@ -205,8 +205,8 @@ class InvoiceGenerator
      */
     public function renderInvoiceMailAttachment(ActiveRow $payment)
     {
-        if (!$payment->user->invoice || $payment->user->disable_auto_invoice) {
-            // user (or admin) disabled invoicing for this account; nothing to generate
+        if (!$payment->user->invoice || $payment->user->disable_auto_invoice || !$payment->payment_gateway->invoice) {
+            // user (or admin) disabled invoicing for this account or payment gateway; nothing to generate
             return false;
         }
 

--- a/src/model/Repository/InvoicesRepository.php
+++ b/src/model/Repository/InvoicesRepository.php
@@ -142,7 +142,7 @@ class InvoicesRepository extends Repository
         }
 
         // admin setting
-        if ($payment->user->disable_auto_invoice) {
+        if ($payment->user->disable_auto_invoice || !$payment->payment_gateway->invoice) {
             return false;
         }
 

--- a/src/presenters/InvoicesAdminPresenter.php
+++ b/src/presenters/InvoicesAdminPresenter.php
@@ -67,7 +67,7 @@ class InvoicesAdminPresenter extends AdminPresenter
             if ($payment->paid_at->diff($now)->days > InvoiceGenerator::CAN_GENERATE_DAYS_LIMIT) {
                 throw new BadRequestException('unable to generate new invoice more than ' . InvoiceGenerator::CAN_GENERATE_DAYS_LIMIT . ' days after the payment');
             }
-            if ($payment->user->invoice == true && !$payment->user->disable_auto_invoice) {
+            if ($payment->user->invoice == true && !$payment->user->disable_auto_invoice && $payment->payment_gateway->invoice == true) {
                 $pdf = $this->invoiceGenerator->generate($payment->user, $payment);
             }
         }

--- a/src/presenters/InvoicesPresenter.php
+++ b/src/presenters/InvoicesPresenter.php
@@ -28,7 +28,7 @@ class InvoicesPresenter extends FrontendPresenter
         if ($payment->invoice) {
             $pdf = $this->invoiceGenerator->renderInvoicePDF($user, $payment);
         } else {
-            if ($payment->user->invoice == true && !$payment->user->disable_auto_invoice) {
+            if ($payment->user->invoice == true && !$payment->user->disable_auto_invoice && $payment->payment_gateway->invoice == true) {
                 if ($payment->paid_at->diff(new DateTime('now'))->days <= InvoiceGenerator::CAN_GENERATE_DAYS_LIMIT) {
                     $pdf = $this->invoiceGenerator->generate($user, $payment);
                 }


### PR DESCRIPTION
Add column to payment_gateway table that can disable invoicing across all payments from given gateway. 
We have some B2B payment gateways with subscriptions charged at regular base, eg. every month. But we don't want to send invoice to users with this gateway.